### PR TITLE
Edited SConstruct to use pkg-config for lib locations

### DIFF
--- a/README
+++ b/README
@@ -20,6 +20,16 @@ to compile on OSX.  Before attempting to compile MidiOSC you should ensure that
 the liblo library and headers are in the appropriate location for your system
 (/usr/lib and /usr/include usually)
 
+Due to complexities with MacOS' installation methods, the scons configuration runs
+pkg-config to ensure correct paths. This, as well as liblo itself, can be installed
+via homebrew:
+
+# install homebrew
+ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" < /dev/null 2> /dev/null
+# install liblo and pkg-config
+brew install pkg-config
+brew install liblo
+
 Compiling
 ---------
 

--- a/README
+++ b/README
@@ -29,6 +29,8 @@ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/
 # install liblo and pkg-config
 brew install pkg-config
 brew install liblo
+# if not already installed, build scons
+brew install scons
 
 Compiling
 ---------

--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,7 @@ if sys.platform == 'darwin':
         FRAMEWORKS = ['CoreMidi', 'CoreAudio', 'CoreFoundation'],
         CCFLAGS = '-D__MACOSX_CORE__'
     )
+    env.ParseConfig('pkg-config --cflags --libs liblo')
 else:
     env = Environment(
         CCFLAGS = '-D__LINUX_ALSA__'


### PR DESCRIPTION
I got frustrated trying to build this on new versions of OSX (tested on Sierra) so I included use of pkg-config and associated instructions for homebrew in the README.